### PR TITLE
ftdetect: force ft, and add star glob to pattern

### DIFF
--- a/ftdetect/tmux.vim
+++ b/ftdetect/tmux.vim
@@ -1,2 +1,1 @@
-autocmd BufNewFile,BufRead tmux.conf setf tmux 
-autocmd BufNewFile,BufRead .tmux.conf setf tmux 
+autocmd BufNewFile,BufRead {.,}tmux*.conf set ft=tmux


### PR DESCRIPTION
This also matches tmux.common.conf.

Fixes https://github.com/zaiste/tmux.vim/issues/2
Fixes https://github.com/zaiste/tmux.vim/pull/3
