### PR TITLE
Syntax update as of tmux 1.9a

### DIFF
--- a/syntax/new-and-deprecated-options.txt
+++ b/syntax/new-and-deprecated-options.txt
@@ -1,0 +1,134 @@
+Last syntax Revision                                      | Tmux 1.9a                    | opt-type | chg
+----------------------------------------------------------------------------------------------------------------
+aggressive-resize                                         | aggressive-resize            |     w    |
+allow-rename                                              | allow-rename                 |     w    |
+alternate-screen                                          | alternate-screen             |     w    |
+                                                          | assume-paste-time            |     g    | New
+automatic-rename                                          | automatic-rename             |     w    |
+                                                          | automatic-rename-format      |     w    | New
+base-index                                                | base-index                   |     g    |
+bell-action                                               | bell-action                  |     g    |
+bell-on-alert                                             | bell-on-alert                |     g    |
+buffer-limit                                              | buffer-limit                 |     s    |
+c0-change-interval                                        | c0-change-interval           |     w    |
+c0-change-trigger                                         | c0-change-trigger            |     w    |
+clock-mode-colour                                         | clock-mode-colour            |     w    |
+clock-mode-style                                          | clock-mode-style             |     w    |
+default-command                                           | default-command              |     g    |
+default-path                                              |                              |     -    | REMOVED !!
+default-shell                                             | default-shell                |     g    |
+default-terminal                                          | default-terminal             |     g    |
+destroy-unattached                                        | destroy-unattached           |     g    |
+detach-on-destroy                                         | detach-on-destroy            |     g    |
+display-panes-active-colour                               | display-panes-active-colour  |     g    |
+display-panes-colour                                      | display-panes-colour         |     g    |
+display-panes-time                                        | display-panes-time           |     g    |
+display-time                                              | display-time                 |     g    |
+escape-time                                               | escape-time                  |     s    |
+exit-unattached                                           | exit-unattached              |     s    |
+                                                          | focus-events                 |     s    | New
+force-height                                              | force-height                 |     w    |
+force-width                                               | force-width                  |     w    |
+history-limit                                             | history-limit                |     g    |
+lock-after-time                                           | lock-after-time              |     g    |
+lock-command                                              | lock-command                 |     g    |
+lock-server                                               | lock-server                  |     g    |
+main-pane-height                                          | main-pane-height             |     w    |
+main-pane-width                                           | main-pane-width              |     w    |
+message-[command-]attr                                    | message-[command-]attr       |     g    | Deprecated
+message-[command-]bg                                      | message-[command-]bg         |     g    | Deprecated
+message-[command-]fg                                      | message-[command-]fg         |     g    | Deprecated
+                                                          | message-[command-]style      |     g    | New
+message-limit                                             | message-limit                |     g    |
+mode-attr                                                 | mode-attr                    |     w    | Deprecated
+mode-bg                                                   | mode-bg                      |     w    | Deprecated
+mode-fg                                                   | mode-fg                      |     w    | Deprecated
+mode-keys                                                 | mode-keys                    |     w    |
+mode-mouse                                                | mode-mouse                   |     w    |
+                                                          | mode-style                   |     w    | New
+monitor-activity                                          | monitor-activity             |     w    |
+monitor-content                                           | monitor-content              |     w    |
+                                                          | monitor-silence              |     w    | New
+mouse-resize-pane                                         | mouse-resize-pane            |     g    |
+mouse-select-pane                                         | mouse-select-pane            |     g    |
+mouse-select-window                                       | mouse-select-window          |     g    |
+mouse-utf8                                                | mouse-utf8                   |     g    |
+other-pane-height                                         | other-pane-height            |     w    |
+other-pane-width                                          | other-pane-width             |     w    |
+pane-active-border-bg                                     | pane-active-border-bg        |     g    | Deprecated
+pane-active-border-fg                                     | pane-active-border-fg        |     g    | Deprecated
+                                                          | pane-active-border-style     |     g    | New
+pane-base-index                                           | pane-base-index              |     w    |
+pane-border-bg                                            | pane-border-bg               |     g    | Deprecated
+pane-border-fg                                            | pane-border-fg               |     g    | Deprecated
+                                                          | pane-border-style            |     g    | New
+prefix                                                    | prefix                       |     g    |
+prefix2                                                   | prefix2                      |     g    |
+quiet                                                     | quiet                        |     s    |
+remain-on-exit                                            | remain-on-exit               |     w    |
+renumber-windows                                          | renumber-windows             |     g    |
+repeat-time                                               | repeat-time                  |     g    |
+set-clipboard                                             | set-clipboard                |     s    |
+set-remain-on-exit                                        | set-remain-on-exit           |     g    |
+set-titles                                                | set-titles                   |     g    |
+set-titles-string                                         | set-titles-string            |     g    |
+status                                                    | status                       |     g    |
+status-attr                                               | status-attr                  |     g    | Deprecated
+status-bg                                                 | status-bg                    |     g    | Deprecated
+status-fg                                                 | status-fg                    |     g    | Deprecated
+status-interval                                           | status-interval              |     g    |
+status-justify                                            | status-justify               |     g    |
+status-keys                                               | status-keys                  |     g    |
+status-left                                               | status-left                  |     g    |
+status-left-attr                                          | status-left-attr             |     g    | Deprecated
+status-left-bg                                            | status-left-bg               |     g    | Deprecated
+status-left-fg                                            | status-left-fg               |     g    | Deprecated
+status-left-length                                        | status-left-length           |     g    |
+                                                          | status-left-style            |     g    | New
+status-position                                           | status-position              |     g    |
+status-right                                              | status-right                 |     g    |
+status-right-attr                                         | status-right-attr            |     g    | Deprecated
+status-right-bg                                           | status-right-bg              |     g    | Deprecated
+status-right-fg                                           | status-right-fg              |     g    | Deprecated
+status-right-length                                       | status-right-length          |     g    |
+                                                          | status-right-style           |     g    | New
+                                                          | status-style                 |     g    | New
+status-utf8                                               | status-utf8                  |     g    |
+synchronize-panes                                         | synchronize-panes            |     w    |
+terminal-overrides                                        | terminal-overrides           |     g    |
+uft8                                                      | utf8                         |     w    |
+update-environment                                        | update-environment           |     g    |
+visual-activity                                           | visual-activity              |     g    |
+visual-bell                                               | visual-bell                  |     g    |
+visual-content                                            | visual-content               |     g    |
+visual-silence                                            | visual-silence               |     g    |
+window-status-activity-attr                               | window-status-activity-attr  |     w    | Deprecated
+window-status-activity-bg                                 | window-status-activity-bg    |     w    | Deprecated
+window-status-activity-fg                                 | window-status-activity-fg    |     w    | Deprecated
+                                                          | window-status-activity-style |     w    | New
+window-status-attr                                        | window-status-attr           |     w    | Deprecated
+window-status-bell-attr                                   | window-status-bell-attr      |     w    | Deprecated
+window-status-bell-bg                                     | window-status-bell-bg        |     w    | Deprecated
+window-status-bell-fg                                     | window-status-bell-fg        |     w    | Deprecated
+                                                          | window-status-bell-style     |     w    | New
+window-status-bg                                          | window-status-bg             |     w    | Deprecated
+window-status-content-attr                                | window-status-content-attr   |     w    | Deprecated
+window-status-content-bg                                  | window-status-content-bg     |     w    | Deprecated
+window-status-content-fg                                  | window-status-content-fg     |     w    | Deprecated
+                                                          | window-status-content-style  |     w    | New
+window-status-current-attr                                | window-status-current-attr   |     w    | Deprecated
+window-status-current-bg                                  | window-status-current-bg     |     w    | Deprecated
+window-status-current-fg                                  | window-status-current-fg     |     w    | Deprecated
+window-status-current-format                              | window-status-current-format |     w    |
+                                                          | window-status-current-style  |     w    | New
+window-status-fg                                          | window-status-fg             |     w    | Deprecated
+window-status-format                                      | window-status-format         |     w    | Deprecated
+                                                          | window-status-last-attr      |     w    | Deprecated
+                                                          | window-status-last-bg        |     w    | Deprecated
+                                                          | window-status-last-fg        |     w    | Deprecated
+                                                          | window-status-last-style     |     w    | New
+                                                          | window-status-separator      |     w    | New
+                                                          | window-status-style          |     w    | New
+word-separators                                           | word-separators              |     g    |
+                                                          | wrap-search                  |     w    | New
+xterm-keys                                                | xterm-keys                   |     w    |

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -31,7 +31,7 @@ syn keyword tmuxCmds command-prompt setb set-buffer showb show-buffer lsb
 syn keyword tmuxCmds list-buffers deleteb delete-buffer lscm list-commands
 syn keyword tmuxCmds movew move-window respawnw respawn-window
 syn keyword tmuxCmds source[-file] info server-info clock-mode lock[-server]
-syn keyword tmuxCmds saveb save-buffer killp 
+syn keyword tmuxCmds saveb save-buffer killp wait[-for]
 syn keyword tmuxCmds kill-pane resizep resize-pane selectp select-pane swapp
 syn keyword tmuxCmds swap-pane splitw split-window choose-session
 syn keyword tmuxCmds choose-window loadb load-buffer suspendc

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -50,7 +50,7 @@ syn keyword tmuxOptsSet prefix prefix2 status status-fg status-bg bell-action
 syn keyword tmuxOptsSet default-command history-limit status-left status-right
 syn keyword tmuxOptsSet status-interval set-titles display-time buffer-limit
 syn keyword tmuxOptsSet status-left-length status-right-length status-position
-syn keyword tmuxOptsSet message-[command-]bg lock-after-time default-path
+syn keyword tmuxOptsSet message-[command-]bg lock-after-time assume-paste-time 
 syn keyword tmuxOptsSet message-[command-]attr status-attr set-remain-on-exit
 syn keyword tmuxOptsSet status-utf8 default-terminal visual-activity repeat-time
 syn keyword tmuxOptsSet visual-bell visual-content status-justify status-keys
@@ -58,16 +58,17 @@ syn keyword tmuxOptsSet terminal-overrides status-left-attr status-left-bg
 syn keyword tmuxOptsSet status-left-fg status-right-attr status-right-bg
 syn keyword tmuxOptsSet status-right-fg update-environment base-index
 syn keyword tmuxOptsSet display-panes-colour display-panes-time default-shell
-syn keyword tmuxOptsSet set-titles-string lock-command lock-server
+syn keyword tmuxOptsSet set-titles-string lock-command lock-server status-style 
 syn keyword tmuxOptsSet mouse-select-pane message-limit quiet escape-time
 syn keyword tmuxOptsSet pane-active-border-bg pane-active-border-fg
 syn keyword tmuxOptsSet pane-border-bg pane-border-fg message-[command-]fg
 syn keyword tmuxOptsSet display-panes-active-colour alternate-screen
-syn keyword tmuxOptsSet detach-on-destroy word-separators
+syn keyword tmuxOptsSet detach-on-destroy word-separators message-[command-]style 
 syn keyword tmuxOptsSet destroy-unattached exit-unattached set-clipboard
 syn keyword tmuxOptsSet bell-on-alert mouse-select-window mouse-utf8
-syn keyword tmuxOptsSet mouse-resize-pane
+syn keyword tmuxOptsSet mouse-resize-pane pane-active-border-style 
 syn keyword tmuxOptsSet message-[command-]fg renumber-windows visual-silence
+syn keyword tmuxOptsSet pane-border-style status-left-style status-right-style focus-events 
 
 syn keyword tmuxOptsSetw monitor-activity aggressive-resize force-width
 syn keyword tmuxOptsSetw force-height remain-on-exit uft8 mode-fg mode-bg
@@ -78,15 +79,18 @@ syn keyword tmuxOptsSetw main-pane-width main-pane-height monitor-content
 syn keyword tmuxOptsSetw window-status-current-attr window-status-current-bg
 syn keyword tmuxOptsSetw window-status-current-fg mode-mouse synchronize-panes
 syn keyword tmuxOptsSetw window-status-format window-status-current-format
-syn keyword tmuxOptsSetw window-status-activity-attr
+syn keyword tmuxOptsSetw window-status-activity-attr mode-style wrap-search 
 syn keyword tmuxOptsSetw window-status-activity-bg window-status-activity-fg
-syn keyword tmuxOptsSetw window-status-bell-attr
+syn keyword tmuxOptsSetw window-status-bell-attr window-status-activity-style
 syn keyword tmuxOptsSetw window-status-bell-bg window-status-bell-fg
-syn keyword tmuxOptsSetw window-status-content-attr
+syn keyword tmuxOptsSetw window-status-content-attr window-status-content-style 
 syn keyword tmuxOptsSetw window-status-content-bg window-status-content-fg
 syn keyword tmuxOptsSetw pane-base-index other-pane-height other-pane-width
 syn keyword tmuxOptsSetw allow-rename c0-change-interval c0-change-trigger
 syn keyword tmuxOptsSetw layout-history-limit monitor-silence utf8 wrap-search
+syn keyword tmuxOptsSetw automatic-rename-format monitor-silence window-status-bell-style
+syn keyword tmuxOptsSetw window-status-last-style window-status-separator
+syn keyword tmuxOptsSetw window-status-current-style window-status-style 
 
 syn keyword tmuxLayoutName even-horizontal even-vertical 
 syn keyword tmuxLayoutName main-horizontal main-vertical tiled 

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -31,10 +31,10 @@ syn keyword tmuxCmds command-prompt setb set-buffer showb show-buffer lsb
 syn keyword tmuxCmds list-buffers deleteb delete-buffer lscm list-commands
 syn keyword tmuxCmds movew move-window respawnw respawn-window
 syn keyword tmuxCmds source[-file] info server-info clock-mode lock[-server]
-syn keyword tmuxCmds saveb save-buffer killp
+syn keyword tmuxCmds saveb save-buffer killp 
 syn keyword tmuxCmds kill-pane resizep resize-pane selectp select-pane swapp
 syn keyword tmuxCmds swap-pane splitw split-window choose-session
-syn keyword tmuxCmds choose-window loadb load-buffer copyb copy-buffer suspendc
+syn keyword tmuxCmds choose-window loadb load-buffer suspendc
 syn keyword tmuxCmds suspend-client findw find-window breakp break-pane nextl
 syn keyword tmuxCmds next-layout rotatew rotate-window confirm[-before]
 syn keyword tmuxCmds clearhist clear-history selectl select-layout if[-shell]

--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -43,8 +43,7 @@ syn keyword tmuxCmds show-environment choose-client displayp display-panes
 syn keyword tmuxCmds run[-shell] lockc lock-client locks lock-session lsp
 syn keyword tmuxCmds list-panes pipep pipe-pane showmsgs show-messages capturep
 syn keyword tmuxCmds capture-pane joinp join-pane choose-buffer
-syn keyword tmuxCmds even-horizontal even-vertical main-horizontal main-vertical
-syn keyword tmuxCmds tiled choose-list lastp last-pane movep move-pane
+syn keyword tmuxCmds choose-list lastp last-pane movep move-pane
 syn keyword tmuxCmds prevl previous-layout prev[-window] respawnp respawn-pane
 
 syn keyword tmuxOptsSet prefix prefix2 status status-fg status-bg bell-action
@@ -89,6 +88,9 @@ syn keyword tmuxOptsSetw pane-base-index other-pane-height other-pane-width
 syn keyword tmuxOptsSetw allow-rename c0-change-interval c0-change-trigger
 syn keyword tmuxOptsSetw layout-history-limit monitor-silence utf8 wrap-search
 
+syn keyword tmuxLayoutName even-horizontal even-vertical 
+syn keyword tmuxLayoutName main-horizontal main-vertical tiled 
+
 syn keyword tmuxTodo FIXME NOTE TODO XXX contained
 
 syn match tmuxKey               /\(C-\|M-\|\^\)\+\S\+/  display
@@ -110,6 +112,7 @@ hi def link tmuxNumber              Number
 hi def link tmuxOptions             Identifier
 hi def link tmuxOptsSet             Function
 hi def link tmuxOptsSetw            Function
+hi def link tmuxLayoutName          Function
 hi def link tmuxString              String
 hi def link tmuxTodo                Todo
 hi def link tmuxVariable            Constant


### PR DESCRIPTION
I've updated the keywords definitions to bring tmux.vim on par with tmux 1.9a. Removed some now-illegal keywords, and added a whole bunch of the new options.

The *-style keywords are replacing the *foo-bg, foo-fg* and *foo-attr* keywords, which are getting deprecated. Theme enthusiasts and tmux+vim users will benefit from the updated syntax.

Also, i added a summary of new, deprecated and removed keywords in a handy txt table (vim powered, of course) 

I thought of changing the highlighting for deprecated functions, so you'd be warned about them going away in the next couple of versions, ¿do you think it's a good Idea?

Best Regards, H-Lo.