### PR TITLE
Set proper comment string on tmux.conf

### DIFF
--- a/ftdetect/tmux.vim
+++ b/ftdetect/tmux.vim
@@ -1,1 +1,2 @@
 autocmd BufNewFile,BufRead {.,}tmux*.conf set ft=tmux
+autocmd BufNewFile,BufRead {.,}tmux*.conf setlocal commentstring=#\ %s


### PR DESCRIPTION
So it uses # instead /**/